### PR TITLE
Honeycomb add category

### DIFF
--- a/event_processor/event_processor/apis/honeycomb.py
+++ b/event_processor/event_processor/apis/honeycomb.py
@@ -34,5 +34,6 @@ class Honeycomb(ApiSpider):
                     'start_time': docs['startTime'],
                     'end_time': docs['endTime']
                 },
-                'url': f'{self.base_url}event/{docs["id"]}'
+                'url': f'{self.base_url}event/{docs["id"]}',
+                'category': docs['category']['name']
             }

--- a/event_processor/event_processor/apis/honeycomb.py
+++ b/event_processor/event_processor/apis/honeycomb.py
@@ -4,7 +4,6 @@ from scrapy import Item
 from scrapy.loader import ItemLoader
 from gql import gql
 
-from event_processor.models.category import Category
 from event_processor.util.data_utils import DataUtils
 from event_processor.base.custom_spiders import ApiSpider
 from event_processor.graphql_definitions.honeycomb import definition
@@ -16,10 +15,10 @@ class Honeycomb(ApiSpider):
     def __init__(self, name=None, **kwargs):
         super().__init__(self, 'The Honeycomb Project', 'https://events.thehoneycombproject.org/', date_format = '%a %b %d %Y %H:%M:%S', **kwargs)
         self.gql_url = 'https://the-honeycomb-project-api.herokuapp.com/gql'
-    
+
     def parse(self, response):
         return self.get_events()
-    
+
     def get_events(self):
         response = self.get_response_graphql(url=self.gql_url, gql_query=definition, params={'search': {'published': True, 'view': 'grid'}})
 

--- a/event_processor/event_processor/apis/library_events.py
+++ b/event_processor/event_processor/apis/library_events.py
@@ -1,7 +1,6 @@
 import time
 from scrapy import Item
 from scrapy.loader import ItemLoader
-from event_processor.models.category import Category
 from event_processor.util.data_utils import DataUtils
 from event_processor.base.custom_spiders import ApiSpider
 import scrapy
@@ -12,18 +11,18 @@ class LibraryEvents(ApiSpider):
     MAX_ROWS = 50
 
     name = 'library'
-    
+
     def __init__(self, name=None, **kwargs):
         super().__init__(self, 'Chicago Public Library', 'https://chipublib.bibliocommons.com/', date_format = '%Y-%m-%d', **kwargs)
-    
+
     def parse(self, response):
         return self.get_events()
 
     def get_next_events_json(self, start):
         request_params = {
-            'client_scope': 'events', 
+            'client_scope': 'events',
             'query': f'start={start}&rows={self.MAX_ROWS}',
-            'facet_fields': 'branch_location_id', 
+            'facet_fields': 'branch_location_id',
             'local_start': f'{self.start_date} TO {self.end_date}',
             'include_near_location': 'false'
         }
@@ -43,23 +42,23 @@ class LibraryEvents(ApiSpider):
             # Keep querying until no more data is returned
             more_data = num_results > 0
             start += num_results
-        
+
         return events_json
 
     def get_locations_json(self, location_category):
         # location_category = 'locations' for branch locations and 'places' for non-branch locations
         request_params = {
-            'client_scope': 'events', 
+            'client_scope': 'events',
             'limit': '0'
         }
         return self.get_response_json(endpoint='events/' + location_category, request_params=request_params, property_to_return = location_category)
-    
+
     def get_branch_locations_json(self):
         return self.get_locations_json('locations')
 
     def get_nonbranch_locations_json(self):
         return self.get_locations_json('places')
-    
+
     def get_locations_list(self, get_locations_func):
         return { location['id']: location['address'] for location in get_locations_func() }
 
@@ -99,7 +98,7 @@ class LibraryEvents(ApiSpider):
             # Don't show cancelled or full events
             if details['is_cancelled'] == True or event['is_full'] == True:
                 continue
-            
+
             yield {
                 'title': details['title'],
                 'description': details['description'],
@@ -111,5 +110,5 @@ class LibraryEvents(ApiSpider):
                 },
                 'url': f'{self.base_url}events/search/index/event/{event["id"]}',
                 'price': 0.0,
-                'category': Category.LIBRARY
+                'category': 'LIBRARY'
             }

--- a/event_processor/event_processor/models/event.py
+++ b/event_processor/event_processor/models/event.py
@@ -11,16 +11,16 @@ def custom_field():
 
 def price_field():
     return scrapy.Field(input_processor=MapCompose(
-            lambda value: value.replace('$', '') if type(value) == str else value, 
-            DataUtils.remove_html, float), 
+            lambda value: value.replace('$', '') if type(value) == str else value,
+            DataUtils.remove_html, float),
         output_processor=TakeFirst())
 
 def url_field():
-    return scrapy.Field(input_processor=MapCompose(DataUtils.remove_html, lambda value: value.rstrip('//')), 
+    return scrapy.Field(input_processor=MapCompose(DataUtils.remove_html, lambda value: value.rstrip('//')),
     output_processor=Join())
 
 def category_field():
-    return scrapy.Field(input_processor=MapCompose(lambda value: value.name), output_processor=Join())
+    return scrapy.Field(output_processor=Join())
 
 def address_field():
     def parse_address(value):
@@ -28,7 +28,7 @@ def address_field():
         contains_field = lambda field: any(address_part[1] == field for address_part in parsed)
         default_field = lambda field, default: f' {default}' if not contains_field(field) else ''
         return f'{value}{default_field("PlaceName", "Chicago")}{default_field("StateName", "IL")}'
-        
+
     return scrapy.Field(input_processor=MapCompose(
             DataUtils.remove_html,
             parse_address),
@@ -93,13 +93,13 @@ class EventLoader():
 class EventManager:
     def __init__(self):
         self.events = {}
-    
+
     def update(self, key, event):
         # Add properties to the event if it has been created already, else create a new event
         if key in self.events:
             self.events[key].update(event)
         else:
             self.events[key] = event
-    
+
     def to_dicts(self):
         return [dict(event) for event in list(self.events.values())]

--- a/event_processor/event_processor/scrapers/history_spider.py
+++ b/event_processor/event_processor/scrapers/history_spider.py
@@ -4,7 +4,6 @@ from scrapy.spiders import Rule
 from event_processor.base.custom_spiders import ScraperCrawlSpider
 from scrapy.linkextractors import LinkExtractor
 
-from event_processor.models.category import Category
 from event_processor.util.data_utils import DataUtils
 
 class HistorySpider(ScraperCrawlSpider):
@@ -24,7 +23,7 @@ class HistorySpider(ScraperCrawlSpider):
                 'start_date': self.start_date,
                 'end_date': self.end_date
             })
-        
+
 
     def parse_start_url(self, response):
         def get_full_date(xpath_result):
@@ -39,7 +38,7 @@ class HistorySpider(ScraperCrawlSpider):
                 else:
                     result.append(f'{text} {current_month}')
             return result
-        
+
         return {
             'title': response.css('a.title::text').extract(),
             'url': response.css('a.title::attr(href)').extract(),

--- a/event_processor/event_processor/scrapers/wpbcc_spider.py
+++ b/event_processor/event_processor/scrapers/wpbcc_spider.py
@@ -4,8 +4,6 @@ from scrapy.spiders import Rule
 from event_processor.base.custom_spiders import ScraperCrawlSpider
 from scrapy.linkextractors import LinkExtractor
 
-from event_processor.models.category import Category
-
 class WpbccSpider(ScraperCrawlSpider):
     name = 'wpbcc'
     allowed_domains = ['www.wickerparkbucktown.com']
@@ -26,7 +24,7 @@ class WpbccSpider(ScraperCrawlSpider):
         base_selector = response.css('.listerContent')
         def sibling_extract(field):
             return self.empty_check_extract(base_selector, self.xpath_func, f'div/span[contains(text(), "{field}: ")]/following-sibling::text()')
-        
+
         return {
             'title': response.css('.listerItem h2 a::text').extract(),
             'url': response.css('.listerItem h2 a::attr(href)').extract(),


### PR DESCRIPTION
This PR contains two small changes. Firstly I removed all the Category imports. This enum was only in use for the library scraper and only to provide the category `LIBRARY`. Now the category will be stored as a string, for that a small adaption in the `event` model `category_field` method was necessary.

With this change it is now possible to store any string as category. I adapted the honeycomb scraper to now also store the category field the GraphQL provides.

The hope is that this category field can be used as training data to use NLP to find categories for all events.