### PR TITLE
not diy chi scraper

### DIFF
--- a/event_processor/event_processor/base/aggregator_base.py
+++ b/event_processor/event_processor/base/aggregator_base.py
@@ -83,3 +83,8 @@ class AggregatorBase:
         return self.session.post(config.scheduler_spider_complete, 
                             json={'jobid': self.jobid, 'errored': self.is_errored, 'logs': logs}, 
                             headers={'Content-Type': 'application/json'})
+
+    def item_filter(self, item):
+        """Specify a filter for event items. This item should return True if 
+           the item should be included in the results and False if not. """
+        return True  

--- a/event_processor/event_processor/base/spider_base.py
+++ b/event_processor/event_processor/base/spider_base.py
@@ -44,9 +44,4 @@ class SpiderBase(AggregatorBase):
             if len(value) != count:
                 raise ValueError(f'{self.organization}: Time selectors returned data of differing lengths')
         return [{key: value[i] for key, value in kwargs.items()} for i in range(count)]
-
-    def item_filter(self, item):
-        """Specify a filter for event items. This item should return True if 
-           the item should be include in the results and False if not. """
-        return True  
         

--- a/event_processor/event_processor/base/spider_base.py
+++ b/event_processor/event_processor/base/spider_base.py
@@ -45,4 +45,8 @@ class SpiderBase(AggregatorBase):
                 raise ValueError(f'{self.organization}: Time selectors returned data of differing lengths')
         return [{key: value[i] for key, value in kwargs.items()} for i in range(count)]
 
+    def item_filter(self, item):
+        """Specify a filter for event items. This item should return True if 
+           the item should be include in the results and False if not. """
+        return True  
         

--- a/event_processor/event_processor/scrapers/notdiy_spider.py
+++ b/event_processor/event_processor/scrapers/notdiy_spider.py
@@ -1,0 +1,49 @@
+
+# this spider should try to ONLY get volunteer relevant events from DIY
+# the lazy way of doing that is to try and only extract evnets with the string "volunteer" somewhere in it? 
+
+# -*- coding: utf-8 -*-
+from event_processor.base.custom_spiders import ScraperCrawlSpider
+from scrapy.spiders import Rule
+from scrapy.linkextractors import LinkExtractor
+
+class NotDIYSpider(ScraperCrawlSpider):
+    """This spider scrapes the not diy chi website, but will only keep events which have the keyword
+        'volunteer' somewhere in its title or description."""
+    name = 'notdiychi'
+    allowed_domains = ['notdiychi.com']
+    start_urls = ['https://notdiychi.com/']
+    enabled = True
+
+    rules = (
+        Rule(LinkExtractor(restrict_css = '.inner-content .event-title a'), callback="parse_page", follow=True),
+    ) 
+ 
+    def __init__(self, name=None, **kwargs):
+        super().__init__(self, 'not diy chi', 'https://notdiychi.com/', date_format='%A, %B %d', **kwargs)
+    
+    def item_filter(self, item): 
+        return 'volunteer' in item['title'] or 'volunteer' in item['description']
+
+    def parse_page(self, response): 
+        def event_date_process(str_full):
+            dt_arr = str_full[0].split('~')
+            if len(dt_arr) > 0:
+                return [dt_arr[0]]
+            return ['']
+        def event_time_process(str_full):
+            tm_arr = str_full[0].split('~')
+            if len(tm_arr) > 0:
+                return [tm_arr[2]]
+            return ['']
+        eresp = response.css('.inner-content')
+        return {
+            'title': self.empty_check_extract(eresp, self.css_func, '.page-title::text'),
+            'url': self.empty_check_extract(eresp, self.css_func, 'a[href]::attr(href)'), 
+            'event_time': self.create_time_data(
+                date=event_date_process(self.empty_check_extract(eresp, self.css_func, '.event-date-single::text')),
+                time=event_time_process(self.empty_check_extract(eresp, self.css_func, '.event-date-single::text'))
+            ),
+            'address': self.empty_check_extract(eresp, self.css_func, 'h3.single-event-venue::text'),
+            'description': self.empty_check_extract(eresp, self.css_func, '.event-details-single::text')
+        }

--- a/event_processor/event_processor/scrapers/notdiy_spider.py
+++ b/event_processor/event_processor/scrapers/notdiy_spider.py
@@ -26,23 +26,18 @@ class NotDIYSpider(ScraperCrawlSpider):
         return 'volunteer' in item['title'] or 'volunteer' in item['description']
 
     def parse_page(self, response): 
-        def event_date_process(str_full):
+        def event_date_extract(str_full, index_to_extract):
             dt_arr = str_full[0].split('~')
-            if len(dt_arr) > 0:
-                return [dt_arr[0]]
-            return ['']
-        def event_time_process(str_full):
-            tm_arr = str_full[0].split('~')
-            if len(tm_arr) > 0:
-                return [tm_arr[2]]
-            return ['']
+            if len(dt_arr) >= index_to_extract:
+                return [dt_arr[index_to_extract]]
+            return [''] 
         eresp = response.css('.inner-content')
         return {
             'title': self.empty_check_extract(eresp, self.css_func, '.page-title::text'),
             'url': self.empty_check_extract(eresp, self.css_func, 'a[href]::attr(href)'), 
             'event_time': self.create_time_data(
-                date=event_date_process(self.empty_check_extract(eresp, self.css_func, '.event-date-single::text')),
-                time=event_time_process(self.empty_check_extract(eresp, self.css_func, '.event-date-single::text'))
+                date=event_date_extract(self.empty_check_extract(eresp, self.css_func, '.event-date-single::text'), 0),
+                time=event_date_extract(self.empty_check_extract(eresp, self.css_func, '.event-date-single::text'), 2)
             ),
             'address': self.empty_check_extract(eresp, self.css_func, 'h3.single-event-venue::text'),
             'description': self.empty_check_extract(eresp, self.css_func, '.event-details-single::text')

--- a/event_processor/event_processor/scrapy_impl/pipelines.py
+++ b/event_processor/event_processor/scrapy_impl/pipelines.py
@@ -25,6 +25,9 @@ class EventTransformPipeline:
         if 'event_time' in item:
             item['event_time']['date_format'] = spider.date_format
         loader = EventLoader(**item)
+        # see if there is a custom filter for the item
+        if not spider.item_filter(item):
+            raise DropItem('Custom item filter did not allow this event')
         if 'event_time' in loader.item:
             time = loader.item['event_time']
             if self.time_utils.time_range_is_between(time['start_timestamp'], time['end_timestamp'], spider.start_timestamp, spider.end_timestamp):


### PR DESCRIPTION
This scraper scrapes the https://notdiychi.com/ but only includes events with the keyword 'volunteer' in the title or description.

this adds an 'item_filter' which can be overridden by scrapers to include or exclude scraped events. (not sure if there is an immediately obvious more efficient way of doing this) 